### PR TITLE
Fix timestamp inputs to 'Europe/Stockholm' timezone.

### DIFF
--- a/lib/tiki/events.ex
+++ b/lib/tiki/events.ex
@@ -77,6 +77,24 @@ defmodule Tiki.Events do
   end
 
   @doc """
+  Gets statistics for an event. Returns a map with stats. Current statistics:
+
+  * `:total_sales`, total sales in SEK
+  * `:tickets_sold` total tickets sold
+  """
+  def get_event_stats!(id) do
+    query =
+      from e in Event,
+        where: e.id == ^id,
+        join: o in assoc(e, :orders),
+        join: t in assoc(o, :tickets),
+        where: o.status == :paid,
+        select: %{total_sales: sum(o.price), tickets_sold: count(t.id)}
+
+    Repo.one!(query)
+  end
+
+  @doc """
   Creates a event.
 
   ## Examples

--- a/lib/tiki/events/event.ex
+++ b/lib/tiki/events/event.ex
@@ -18,6 +18,7 @@ defmodule Tiki.Events.Event do
     belongs_to :default_form, Tiki.Forms.Form
 
     has_many :ticket_batches, Tiki.Tickets.TicketBatch
+    has_many :orders, Tiki.Orders.Order
 
     belongs_to :team, Tiki.Teams.Team
 

--- a/lib/tiki/events/event.ex
+++ b/lib/tiki/events/event.ex
@@ -5,7 +5,7 @@ defmodule Tiki.Events.Event do
   @primary_key {:id, Ecto.UUID, autogenerate: false}
   schema "events" do
     field :description, :string
-    field :event_date, :utc_datetime
+    field :event_date, Tiki.Types.DatetimeStockholm
     field :name, :string
     field :location, :string
     field :image_url, :string

--- a/lib/tiki/orders.ex
+++ b/lib/tiki/orders.ex
@@ -54,7 +54,7 @@ defmodule Tiki.Orders do
       ]
   end
 
-  def get_order_log!(id) do
+  def get_order_logs(id) do
     Repo.all(from ol in AuditLog, where: ol.order_id == ^id, order_by: {:desc, ol.inserted_at})
   end
 

--- a/lib/tiki/tickets/ticket_type.ex
+++ b/lib/tiki/tickets/ticket_type.ex
@@ -10,16 +10,16 @@ defmodule Tiki.Tickets.TicketType do
     field :promo_code, :string
 
     # TODO: implement release time and expire time
-    field :release_time, :utc_datetime
-    field :expire_time, :utc_datetime
+    field :release_time, Tiki.Types.DatetimeStockholm
+    field :expire_time, Tiki.Types.DatetimeStockholm
 
     # ticket limits in orders
     field :purchase_limit, :integer
     field :purchasable, :boolean, default: true
 
     # For events with different time slots for different ticket types, eg. spex showings on multiple days
-    field :start_time, :utc_datetime
-    field :end_time, :utc_datetime
+    field :start_time, Tiki.Types.DatetimeStockholm
+    field :end_time, Tiki.Types.DatetimeStockholm
 
     belongs_to :ticket_batch, Tiki.Tickets.TicketBatch
     belongs_to :form, Tiki.Forms.Form

--- a/lib/tiki/types/datetime_stockholm.ex
+++ b/lib/tiki/types/datetime_stockholm.ex
@@ -1,0 +1,88 @@
+defmodule Tiki.Types.DatetimeStockholm do
+  use Ecto.Type
+
+  # still store as utc_datetime
+  def type, do: :utc_datetime
+
+  def cast(value), do: cast_stockholm_datetime(value)
+
+  defp cast_stockholm_datetime(nil), do: {:ok, nil}
+
+  defp cast_stockholm_datetime("-" <> rest) do
+    with {:ok, utc_datetime} <- cast_stockholm_datetime(rest) do
+      {:ok, %{utc_datetime | year: utc_datetime.year * -1}}
+    end
+  end
+
+  defp cast_stockholm_datetime(
+         <<year::4-bytes, ?-, month::2-bytes, ?-, day::2-bytes, sep, hour::2-bytes, ?:,
+           minute::2-bytes>>
+       )
+       when sep in [?\s, ?T] do
+    with {:ok, naive_dt} <-
+           NaiveDateTime.new(to_i(year), to_i(month), to_i(day), to_i(hour), to_i(minute), 0),
+         {:ok, dt} <- to_utc(naive_dt) do
+      {:ok, dt}
+    else
+      _ -> :error
+    end
+  end
+
+  defp cast_stockholm_datetime(binary) when is_binary(binary) do
+    case DateTime.from_iso8601(binary) do
+      {:ok, datetime, _offset} ->
+        {:ok, datetime}
+
+      {:error, :missing_offset} ->
+        case NaiveDateTime.from_iso8601(binary) do
+          {:ok, naive_datetime} -> to_utc(naive_datetime)
+          {:error, _} -> :error
+        end
+
+      {:error, _} ->
+        :error
+    end
+  end
+
+  defp cast_stockholm_datetime(%DateTime{} = datetime) do
+    case datetime |> DateTime.to_unix(:microsecond) |> DateTime.from_unix(:microsecond) do
+      {:ok, _} = ok -> ok
+      {:error, _} -> :error
+    end
+  end
+
+  defp cast_stockholm_datetime(%NaiveDateTime{} = datetime), do: to_utc(datetime)
+
+  def load(%DateTime{} = datetime), do: from_utc(datetime)
+  def load(%NaiveDateTime{} = datetime), do: from_utc(datetime)
+  def load(_), do: :error
+
+  def dump(%DateTime{time_zone: "Etc/UTC"} = dt), do: {:ok, dt}
+  def dump(%DateTime{} = dt), do: {:ok, DateTime.shift_zone!(dt, "Etc/UTC")}
+  def dump(_), do: :error
+
+  defp to_utc(%NaiveDateTime{} = datetime) do
+    case DateTime.from_naive(datetime, "Europe/Stockholm") do
+      {:ok, datetime} -> {:ok, DateTime.shift_zone!(datetime, "Etc/UTC")}
+      _ -> :error
+    end
+  end
+
+  defp from_utc(%DateTime{time_zone: "Etc/UTC"} = datetime) do
+    {:ok, DateTime.shift_zone(datetime, "Europe/Stockholm")}
+  end
+
+  defp from_utc(%NaiveDateTime{} = datetime) do
+    case DateTime.from_naive(datetime, "Etc/UTC") do
+      {:ok, datetime} -> {:ok, DateTime.shift_zone!(datetime, "Europe/Stockholm")}
+      _ -> :error
+    end
+  end
+
+  defp to_i(bin) when is_binary(bin) and byte_size(bin) < 32 do
+    case Integer.parse(bin) do
+      {int, ""} -> int
+      _ -> nil
+    end
+  end
+end

--- a/lib/tiki/types/datetime_stockholm.ex
+++ b/lib/tiki/types/datetime_stockholm.ex
@@ -45,10 +45,7 @@ defmodule Tiki.Types.DatetimeStockholm do
   end
 
   defp cast_stockholm_datetime(%DateTime{} = datetime) do
-    case datetime |> DateTime.to_unix(:microsecond) |> DateTime.from_unix(:microsecond) do
-      {:ok, _} = ok -> ok
-      {:error, _} -> :error
-    end
+    {:ok, datetime}
   end
 
   defp cast_stockholm_datetime(%NaiveDateTime{} = datetime), do: to_utc(datetime)

--- a/lib/tiki_web/components/input.ex
+++ b/lib/tiki_web/components/input.ex
@@ -144,7 +144,7 @@ defmodule TikiWeb.Component.Input do
         type={@type}
         name={@name}
         id={@id}
-        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        value={normalize_value(@type, @value)}
         class={[
           "bg-background ring-offset-background mt-2 flex h-10 w-full rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus:ring-offset-background focus:border-input focus:ring-ring focus:outline-hidden focus:ring-2 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           @errors == [] && "border-input",
@@ -330,5 +330,26 @@ defmodule TikiWeb.Component.Input do
       <.input field={@field} type="text" label={@question.name} default={@default} />
     </div>
     """
+  end
+
+  defp normalize_value("datetime-local", %DateTime{} = datetime) do
+    datetime
+    |> DateTime.shift_zone!("Europe/Stockholm")
+    |> DateTime.to_string()
+    |> to_form_datetime()
+  end
+
+  defp normalize_value("datetime-local", %NaiveDateTime{} = datetime) do
+    datetime
+    |> DateTime.from_naive!("Etc/UTC")
+    |> DateTime.shift_zone!("Europe/Stockholm")
+    |> DateTime.to_string()
+    |> to_form_datetime()
+  end
+
+  defp normalize_value(type, value), do: Phoenix.HTML.Form.normalize_value(type, value)
+
+  defp to_form_datetime(<<date::10-binary, ?\s, hour_minute::5-binary, _rest::binary>>) do
+    {:safe, [date, ?T, hour_minute]}
   end
 end

--- a/lib/tiki_web/live/admin_live/attendees/show.ex
+++ b/lib/tiki_web/live/admin_live/attendees/show.ex
@@ -177,7 +177,9 @@ defmodule TikiWeb.AdminLive.Attendees.Show do
           <span class="text-foreground text-sm">{gettext("Loading...")}</span>
         </:loading>
         <:failed :let={_failure}>
-          {gettext("There was an error loading the payment method")}
+          <span class="text-foreground text-sm">
+            {gettext("There was an error loading the payment method")}
+          </span>
         </:failed>
 
         <dd class="text-foreground mt-1 flex flex-row items-center gap-x-2 text-sm sm:col-span-2 sm:mt-0">
@@ -218,7 +220,9 @@ defmodule TikiWeb.AdminLive.Attendees.Show do
           <span class="text-foreground text-sm">{gettext("Loading...")}</span>
         </:loading>
         <:failed :let={_failure}>
-          {gettext("There was an error loading the payment method")}
+          <span class="text-foreground text-sm">
+            {gettext("There was an error loading the payment method")}
+          </span>
         </:failed>
 
         <dd class="text-foreground mt-1 flex flex-row items-center gap-x-2 text-sm sm:col-span-2 sm:mt-0">
@@ -236,11 +240,14 @@ defmodule TikiWeb.AdminLive.Attendees.Show do
   defp get_payment_method(order) do
     payment_method =
       cond do
-        order.stripe_checkout ->
+        order.stripe_checkout && order.stripe_checkout.payment_method_id ->
           Tiki.Checkouts.retrieve_stripe_payment_method(order.stripe_checkout.payment_method_id)
 
         order.swish_checkout ->
           Tiki.Checkouts.get_swish_payment_request(order.swish_checkout.swish_id)
+
+        true ->
+          {:error, "no saved payment method"}
       end
 
     case payment_method do

--- a/lib/tiki_web/live/admin_live/event/form_component.ex
+++ b/lib/tiki_web/live/admin_live/event/form_component.ex
@@ -42,7 +42,7 @@ defmodule TikiWeb.AdminLive.Event.FormComponent do
           field={@form[:event_date]}
           type="datetime-local"
           label={gettext("Event date")}
-          description={gettext("In UTC")}
+          description={gettext("In 'Europe/Stockholm' timezone")}
         />
 
         <.input field={@form[:location]} type="text" label={gettext("Location")} />

--- a/lib/tiki_web/live/admin_live/event/show.ex
+++ b/lib/tiki_web/live/admin_live/event/show.ex
@@ -17,7 +17,9 @@ defmodule TikiWeb.AdminLive.Event.Show do
 
       if connected?(socket), do: Orders.subscribe(event_id, :purchases)
 
-      {:ok, assign(socket, event: event, online_count: initial_count)}
+      stats = Events.get_event_stats!(event_id)
+
+      {:ok, assign(socket, event: event, online_count: initial_count, stats: stats)}
     else
       {:error, :unauthorized} ->
         {:ok,
@@ -97,7 +99,9 @@ defmodule TikiWeb.AdminLive.Event.Show do
             <.icon name="hero-ticket" class="text-muted-foreground h-4 w-4" />
           </.card_header>
           <.card_content>
-            <div class="text-2xl font-bold">N/A</div>
+            <div class="text-2xl font-bold">
+              {@stats.tickets_sold}
+            </div>
           </.card_content>
         </.card>
         <.card>
@@ -108,7 +112,9 @@ defmodule TikiWeb.AdminLive.Event.Show do
             <.icon name="hero-ticket" class="text-muted-foreground h-4 w-4" />
           </.card_header>
           <.card_content>
-            <div class="text-2xl font-bold">N/A</div>
+            <div class="text-2xl font-bold">
+              {Tiki.Cldr.Number.to_string!(@stats.total_sales, format: "#,##0")} SEK
+            </div>
           </.card_content>
         </.card>
         <.card>

--- a/lib/tiki_web/live/admin_live/event/show.ex
+++ b/lib/tiki_web/live/admin_live/event/show.ex
@@ -68,7 +68,7 @@ defmodule TikiWeb.AdminLive.Event.Show do
       {@event.name}
       <:subtitle>
         <span>
-          {Tiki.Cldr.DateTime.to_string!(@event.event_date, format: :yMMMEd) |> String.capitalize()}
+          {time_to_string(@event.event_date, format: :long) |> String.capitalize()}
         </span>·
         <span>
           {@event.location}

--- a/lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex
+++ b/lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex
@@ -29,13 +29,13 @@ defmodule TikiWeb.AdminLive.Ticket.TicketTypeFormComponent do
           field={@form[:start_time]}
           type="datetime-local"
           label={gettext("Start time")}
-          description={gettext("In UTC")}
+          description={gettext("In 'Europe/Stockholm' timezone")}
         />
         <.input
           field={@form[:end_time]}
           type="datetime-local"
           label={gettext("End time")}
-          description={gettext("In UTC")}
+          description={gettext("In 'Europe/Stockholm' timezone")}
         />
 
         <.input
@@ -69,14 +69,16 @@ defmodule TikiWeb.AdminLive.Ticket.TicketTypeFormComponent do
           field={@form[:release_time]}
           type="datetime-local"
           label={gettext("Release time")}
-          description={gettext("In UTC. Leave blank to make immediately available")}
+          description={
+            gettext("In 'Europe/Stockholm' timezone. Leave blank to make immediately available")
+          }
         />
 
         <.input
           field={@form[:expire_time]}
           type="datetime-local"
           label={gettext("Purchase deadline")}
-          description={gettext("In UTC. Leave blank for none")}
+          description={gettext("In 'Europe/Stockholm' timezone. Leave blank for none")}
         />
 
         <.input

--- a/lib/tiki_web/live/order_live/show.ex
+++ b/lib/tiki_web/live/order_live/show.ex
@@ -74,7 +74,7 @@ defmodule TikiWeb.OrderLive.Show do
                   </dt>
                   <dd class="text-muted-foreground mt-3">
                     <span class="block">
-                      {find_in_response(ticket.form_response, ["namn", "name"])}
+                      {response_name(ticket.form_response)}
                     </span>
                   </dd>
                 </div>
@@ -84,7 +84,7 @@ defmodule TikiWeb.OrderLive.Show do
                   </dt>
                   <dd class="text-muted-foreground mt-3 space-y-3">
                     <p>
-                      {find_in_response(ticket.form_response, "email")}
+                      {response_email(ticket.form_response)}
                     </p>
                   </dd>
                 </div>
@@ -295,12 +295,15 @@ defmodule TikiWeb.OrderLive.Show do
 
   def handle_params(_, _, socket), do: {:noreply, socket}
 
-  defp find_in_response(response, question) when is_binary(question),
-    do: find_in_response(response, [question])
-
-  defp find_in_response(response, questions) when is_list(questions) do
+  defp response_name(response) do
     response.question_responses
-    |> Enum.find(%{}, fn qr -> String.downcase(qr.question.name) in questions end)
+    |> Enum.find(%{}, fn qr -> qr.question.type == :attendee_name end)
+    |> Map.get(:answer, "")
+  end
+
+  defp response_email(response) do
+    response.question_responses
+    |> Enum.find(%{}, fn qr -> qr.question.type == :email end)
     |> Map.get(:answer, "")
   end
 

--- a/lib/tiki_web/live/order_live/show.ex
+++ b/lib/tiki_web/live/order_live/show.ex
@@ -46,7 +46,7 @@ defmodule TikiWeb.OrderLive.Show do
       <h2 class="sr-only">{gettext("Tickets")}</h2>
 
       <div class="space-y-4 md:space-y-8">
-        <.card :for={ticket <- @order.tickets} class="md:max-w-3xl">
+        <.card :for={ticket <- @order.tickets}>
           <div class="px-4 py-6 sm:px-6 lg:grid lg:grid-cols-12 lg:gap-x-8 lg:p-8">
             <div class="flex lg:col-span-7">
               <.link class="size-24" navigate={ticket_path(ticket, @live_action)}>

--- a/lib/tiki_web/live/order_live/ticket.ex
+++ b/lib/tiki_web/live/order_live/ticket.ex
@@ -24,13 +24,21 @@ defmodule TikiWeb.OrderLive.Ticket do
                   event: @ticket.ticket_type.ticket_batch.event.name
                 )}
               </h2>
-              <h3 class="text-foreground">
+              <h3 class="text-foreground mb-1">
                 {@ticket.ticket_type.name}
               </h3>
-              <p :if={@ticket.ticket_type.start_time} class="text-muted-foreground text-sm">
-                {gettext("Start time")}
+              <p class="text-muted-foreground flex flex-row items-center gap-1 text-sm">
+                <.icon name="hero-map-pin" class="text-muted-foreground size-4" />
+
+                {@ticket.ticket_type.ticket_batch.event.location}
+              </p>
+              <p
+                :if={@ticket.ticket_type.start_time}
+                class="text-muted-foreground flex flex-row items-center gap-1 text-sm"
+              >
+                <.icon name="hero-calendar" class="text-muted-foreground size-4" />
                 <time datetime={@ticket.ticket_type.start_time}>
-                  {Tiki.Cldr.DateTime.to_string!(@ticket.ticket_type.start_time, format: :short)}
+                  {time_to_string(@ticket.ticket_type.start_time, format: :short)}
                 </time>
               </p>
               <p class="text-muted-foreground text-sm">

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -108,6 +108,7 @@ msgstr ""
 
 #: lib/tiki_web/components/sidebar.ex:102
 #: lib/tiki_web/live/admin_live/attendees/show.ex:102
+#: lib/tiki_web/live/admin_live/orders/show.ex:18
 #: lib/tiki_web/live/admin_live/ticket/index.ex:16
 #: lib/tiki_web/live/admin_live/ticket/index.ex:129
 #: lib/tiki_web/live/order_live/show.ex:46
@@ -144,7 +145,7 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:97
+#: lib/tiki_web/live/admin_live/attendees/show.ex:99
 #: lib/tiki_web/live/admin_live/dashboard/index.ex:129
 #: lib/tiki_web/live/admin_live/dashboard/index.ex:153
 #: lib/tiki_web/live/admin_live/event/form_component.ex:22
@@ -153,6 +154,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/forms/form.ex:12
 #: lib/tiki_web/live/admin_live/forms/form.ex:158
 #: lib/tiki_web/live/admin_live/forms/index.ex:22
+#: lib/tiki_web/live/admin_live/orders/show.ex:15
 #: lib/tiki_web/live/admin_live/team/form.ex:16
 #: lib/tiki_web/live/admin_live/team/index.ex:23
 #: lib/tiki_web/live/admin_live/team/members.ex:59
@@ -160,7 +162,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:26
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:26
 #: lib/tiki_web/live/order_live/show.ex:73
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:129
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:128
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -242,11 +244,6 @@ msgstr ""
 msgid "Ticket types"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/index.ex:75
-#, elixir-autogen, elixir-format
-msgid "New attendee"
-msgstr ""
-
 #: lib/tiki_web/live/admin_live/attendees/index.ex:66
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -289,7 +286,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/team/form.ex:22
 #: lib/tiki_web/live/admin_live/team/membership_form.ex:33
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:38
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:92
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:94
 #: lib/tiki_web/live/order_live/ticket_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -446,12 +443,13 @@ msgid "from last month"
 msgstr ""
 
 #: lib/tiki_web/live/account_live/settings.ex:22
-#: lib/tiki_web/live/admin_live/attendees/show.ex:98
+#: lib/tiki_web/live/admin_live/attendees/show.ex:100
 #: lib/tiki_web/live/admin_live/forms/form.ex:36
 #: lib/tiki_web/live/admin_live/forms/form.ex:159
+#: lib/tiki_web/live/admin_live/orders/show.ex:16
 #: lib/tiki_web/live/admin_live/team/members.ex:60
 #: lib/tiki_web/live/admin_live/team/show.ex:21
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:136
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:135
 #: lib/tiki_web/live/user_live/registration.ex:27
 #, elixir-autogen, elixir-format
 msgid "Email"
@@ -531,7 +529,7 @@ msgid "New batch"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/ticket/index.ex:32
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:187
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:189
 #, elixir-autogen, elixir-format
 msgid "New ticket type"
 msgstr ""
@@ -568,7 +566,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/team/members.ex:71
 #: lib/tiki_web/live/admin_live/team/show.ex:32
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:48
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:102
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:104
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
@@ -593,13 +591,13 @@ msgstr ""
 msgid "Delete batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:104
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:106
 #, elixir-autogen, elixir-format
 msgid "Delete ticket type"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:47
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:101
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:103
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr ""
@@ -609,7 +607,7 @@ msgstr ""
 msgid "Edit batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:186
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:188
 #, elixir-autogen, elixir-format
 msgid "Edit ticket type"
 msgstr ""
@@ -624,13 +622,14 @@ msgstr ""
 msgid "Number of tickets"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:99
+#: lib/tiki_web/live/admin_live/attendees/show.ex:101
+#: lib/tiki_web/live/admin_live/orders/show.ex:17
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:67
 #, elixir-autogen, elixir-format
 msgid "Price"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:88
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:90
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Promo code"
@@ -641,7 +640,7 @@ msgstr ""
 msgid "Purchasable"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:78
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:80
 #, elixir-autogen, elixir-format
 msgid "Purchase deadline"
 msgstr ""
@@ -656,27 +655,27 @@ msgstr ""
 msgid "Save batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:93
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:95
 #, elixir-autogen, elixir-format
 msgid "Save ticket type"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:85
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:87
 #, elixir-autogen, elixir-format
 msgid "Ticket batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:165
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:167
 #, elixir-autogen, elixir-format
 msgid "Ticket type created successfully"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:143
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:145
 #, elixir-autogen, elixir-format
 msgid "Ticket type deleted successfully"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:152
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:154
 #, elixir-autogen, elixir-format
 msgid "Ticket type updated successfully"
 msgstr ""
@@ -691,12 +690,14 @@ msgstr ""
 msgid "Team"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:59
+#: lib/tiki_web/live/admin_live/orders/show.ex:32
+#: lib/tiki_web/live/admin_live/orders/show.ex:64
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:61
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "Purchase tickets for %{event}. You have %{count} minutes to complete your order."
 msgstr ""
@@ -708,7 +709,7 @@ msgstr ""
 
 #: lib/tiki/orders/order_notifier.ex:115
 #: lib/tiki_web/live/order_live/show.ex:233
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:83
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
@@ -729,12 +730,12 @@ msgstr ""
 msgid "Browse events"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:155
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:114
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Credit card"
 msgstr ""
@@ -746,19 +747,19 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:170
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:169
 #, elixir-autogen, elixir-format
 msgid "Open swish on this device"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:162
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Pay using Swish"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:160
-#: lib/tiki_web/live/admin_live/attendees/show.ex:202
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:103
+#: lib/tiki_web/live/admin_live/attendees/show.ex:159
+#: lib/tiki_web/live/admin_live/attendees/show.ex:201
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:102
 #, elixir-autogen, elixir-format
 msgid "Payment method"
 msgstr ""
@@ -768,7 +769,7 @@ msgstr ""
 msgid "Read more"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:121
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Swish"
 msgstr ""
@@ -783,12 +784,12 @@ msgstr ""
 msgid "You must accept the terms of service."
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:137
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:136
 #, elixir-autogen, elixir-format
 msgid "Your email"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:130
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:129
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -884,7 +885,7 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:68
+#: lib/tiki_web/live/admin_live/attendees/show.ex:67
 #, elixir-autogen, elixir-format
 msgid "Attendeee has not filled in the required ticket information"
 msgstr ""
@@ -899,7 +900,8 @@ msgstr ""
 msgid "Billing summary"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:175
+#: lib/tiki_web/live/admin_live/attendees/show.ex:174
+#: lib/tiki_web/live/admin_live/orders/show.ex:40
 #, elixir-autogen, elixir-format
 msgid "Card details"
 msgstr ""
@@ -909,7 +911,7 @@ msgstr ""
 msgid "Contact information"
 msgstr ""
 
-#: lib/tiki_web/live/order_live/ticket.ex:61
+#: lib/tiki_web/live/order_live/ticket.ex:69
 #, elixir-autogen, elixir-format
 msgid "Edit details"
 msgstr ""
@@ -929,24 +931,29 @@ msgstr ""
 msgid "Fill in ticket information"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:95
+#: lib/tiki_web/live/admin_live/attendees/show.ex:91
+#: lib/tiki_web/live/admin_live/orders/show.ex:12
 #, elixir-autogen, elixir-format
 msgid "Information about order."
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/attendees/show.ex:51
-#: lib/tiki_web/live/admin_live/attendees/show.ex:75
+#: lib/tiki_web/live/admin_live/attendees/show.ex:74
 #, elixir-autogen, elixir-format
 msgid "Information about ticket."
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:178
-#: lib/tiki_web/live/admin_live/attendees/show.ex:219
+#: lib/tiki_web/live/admin_live/attendees/show.ex:177
+#: lib/tiki_web/live/admin_live/attendees/show.ex:218
+#: lib/tiki_web/live/admin_live/orders/show.ex:43
+#: lib/tiki_web/live/admin_live/orders/show.ex:75
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:95
+#: lib/tiki_web/live/admin_live/attendees/show.ex:91
+#: lib/tiki_web/live/admin_live/orders/show.ex:12
+#: lib/tiki_web/live/admin_live/orders/show.ex:162
 #, elixir-autogen, elixir-format
 msgid "Order"
 msgstr ""
@@ -956,7 +963,8 @@ msgstr ""
 msgid "Order information"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:96
+#: lib/tiki_web/live/admin_live/attendees/show.ex:92
+#: lib/tiki_web/live/admin_live/orders/show.ex:13
 #, elixir-autogen, elixir-format
 msgid "Order number"
 msgstr ""
@@ -982,13 +990,14 @@ msgstr ""
 msgid "Saved response"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:54
-#: lib/tiki_web/live/admin_live/attendees/show.ex:83
+#: lib/tiki_web/live/admin_live/attendees/show.ex:53
+#: lib/tiki_web/live/admin_live/attendees/show.ex:81
 #, elixir-autogen, elixir-format
 msgid "Signed up at"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:167
+#: lib/tiki_web/live/admin_live/attendees/show.ex:166
+#: lib/tiki_web/live/admin_live/orders/show.ex:37
 #, elixir-autogen, elixir-format
 msgid "Stripe payment reference"
 msgstr ""
@@ -998,7 +1007,8 @@ msgstr ""
 msgid "Subtotal"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:209
+#: lib/tiki_web/live/admin_live/attendees/show.ex:208
+#: lib/tiki_web/live/admin_live/orders/show.ex:69
 #, elixir-autogen, elixir-format
 msgid "Swish payment reference"
 msgstr ""
@@ -1009,26 +1019,28 @@ msgstr ""
 msgid "Thank you for your order!"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:181
-#: lib/tiki_web/live/admin_live/attendees/show.ex:222
+#: lib/tiki_web/live/admin_live/attendees/show.ex:180
+#: lib/tiki_web/live/admin_live/attendees/show.ex:221
+#: lib/tiki_web/live/admin_live/orders/show.ex:46
+#: lib/tiki_web/live/admin_live/orders/show.ex:78
 #: lib/tiki_web/live/order_live/show.ex:143
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the payment method"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/attendees/show.ex:50
-#: lib/tiki_web/live/admin_live/attendees/show.ex:74
+#: lib/tiki_web/live/admin_live/attendees/show.ex:73
 #, elixir-autogen, elixir-format
 msgid "Ticket"
 msgstr ""
 
-#: lib/tiki_web/live/order_live/ticket.ex:44
+#: lib/tiki_web/live/order_live/ticket.ex:52
 #, elixir-autogen, elixir-format
 msgid "Ticket information"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:57
-#: lib/tiki_web/live/admin_live/attendees/show.ex:86
+#: lib/tiki_web/live/admin_live/attendees/show.ex:56
+#: lib/tiki_web/live/admin_live/attendees/show.ex:84
 #, elixir-autogen, elixir-format
 msgid "Ticket type"
 msgstr ""
@@ -1053,8 +1065,8 @@ msgstr ""
 msgid "Your ticket to %{event}"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:61
-#: lib/tiki_web/live/admin_live/attendees/show.ex:79
+#: lib/tiki_web/live/admin_live/attendees/show.ex:60
+#: lib/tiki_web/live/admin_live/attendees/show.ex:78
 #, elixir-autogen, elixir-format
 msgid "View ticket"
 msgstr ""
@@ -1119,7 +1131,7 @@ msgstr ""
 msgid "Organized by"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:191
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:190
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
@@ -1157,12 +1169,12 @@ msgid "Signup form"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:31
-#: lib/tiki_web/live/order_live/ticket.ex:31
 #, elixir-autogen, elixir-format
 msgid "Start time"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:216
+#: lib/tiki_web/live/admin_live/attendees/show.ex:215
+#: lib/tiki_web/live/admin_live/orders/show.ex:72
 #, elixir-autogen, elixir-format
 msgid "Swish number"
 msgstr ""
@@ -1276,6 +1288,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/forms/form.ex:129
 #: lib/tiki_web/live/admin_live/forms/form.ex:150
 #: lib/tiki_web/live/admin_live/forms/index.ex:61
+#: lib/tiki_web/live/admin_live/orders/show.ex:174
 #: lib/tiki_web/live/admin_live/team/form.ex:62
 #: lib/tiki_web/live/admin_live/team/form.ex:80
 #: lib/tiki_web/live/admin_live/team/form.ex:101
@@ -1380,18 +1393,6 @@ msgstr ""
 msgid "Please contact the event organizer if you have any questions."
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/event/form_component.ex:45
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:32
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:38
-#, elixir-autogen, elixir-format
-msgid "In UTC"
-msgstr ""
-
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:79
-#, elixir-autogen, elixir-format
-msgid "In UTC. Leave blank for none"
-msgstr ""
-
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:146
 #, elixir-autogen, elixir-format
 msgid "Sold out"
@@ -1406,11 +1407,6 @@ msgstr ""
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:142
 #, elixir-autogen, elixir-format
 msgid "Ticket releases at"
-msgstr ""
-
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:72
-#, elixir-autogen, elixir-format
-msgid "In UTC. Leave blank to make immediately available"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/event/form_component.ex:28
@@ -1805,12 +1801,12 @@ msgstr ""
 msgid "Profile updated successfully"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:48
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:50
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Your order was cancelled or has expired. Please try again."
 msgstr ""
@@ -1825,12 +1821,12 @@ msgstr ""
 msgid "Terms"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:145
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:144
 #, elixir-autogen, elixir-format
 msgid "I agree to"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:149
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:148
 #, elixir-autogen, elixir-format
 msgid "the terms of service"
 msgstr ""
@@ -1854,4 +1850,54 @@ msgstr ""
 #: lib/tiki_web/live/order_live/show.ex:41
 #, elixir-autogen, elixir-format
 msgid "View receipt"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:95
+#, elixir-autogen, elixir-format
+msgid "Events and logs"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/event/form_component.ex:45
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:32
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:38
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:81
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone. Leave blank for none"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:73
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone. Leave blank to make immediately available"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:33
+#: lib/tiki_web/live/admin_live/orders/show.ex:65
+#, elixir-autogen, elixir-format
+msgid "Information about payment."
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:36
+#: lib/tiki_web/live/admin_live/orders/show.ex:68
+#, elixir-autogen, elixir-format
+msgid "Payment status"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:35
+#: lib/tiki_web/live/admin_live/orders/show.ex:67
+#, elixir-autogen, elixir-format
+msgid "Payment type"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:14
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:97
+#, elixir-autogen, elixir-format
+msgid "These are all of the order change events that have happened to this order."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -108,6 +108,7 @@ msgstr ""
 
 #: lib/tiki_web/components/sidebar.ex:102
 #: lib/tiki_web/live/admin_live/attendees/show.ex:102
+#: lib/tiki_web/live/admin_live/orders/show.ex:18
 #: lib/tiki_web/live/admin_live/ticket/index.ex:16
 #: lib/tiki_web/live/admin_live/ticket/index.ex:129
 #: lib/tiki_web/live/order_live/show.ex:46
@@ -144,7 +145,7 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:97
+#: lib/tiki_web/live/admin_live/attendees/show.ex:99
 #: lib/tiki_web/live/admin_live/dashboard/index.ex:129
 #: lib/tiki_web/live/admin_live/dashboard/index.ex:153
 #: lib/tiki_web/live/admin_live/event/form_component.ex:22
@@ -153,6 +154,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/forms/form.ex:12
 #: lib/tiki_web/live/admin_live/forms/form.ex:158
 #: lib/tiki_web/live/admin_live/forms/index.ex:22
+#: lib/tiki_web/live/admin_live/orders/show.ex:15
 #: lib/tiki_web/live/admin_live/team/form.ex:16
 #: lib/tiki_web/live/admin_live/team/index.ex:23
 #: lib/tiki_web/live/admin_live/team/members.ex:59
@@ -160,7 +162,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:26
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:26
 #: lib/tiki_web/live/order_live/show.ex:73
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:129
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:128
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -242,11 +244,6 @@ msgstr ""
 msgid "Ticket types"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/index.ex:75
-#, elixir-autogen, elixir-format
-msgid "New attendee"
-msgstr ""
-
 #: lib/tiki_web/live/admin_live/attendees/index.ex:66
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -289,7 +286,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/team/form.ex:22
 #: lib/tiki_web/live/admin_live/team/membership_form.ex:33
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:38
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:92
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:94
 #: lib/tiki_web/live/order_live/ticket_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -446,12 +443,13 @@ msgid "from last month"
 msgstr ""
 
 #: lib/tiki_web/live/account_live/settings.ex:22
-#: lib/tiki_web/live/admin_live/attendees/show.ex:98
+#: lib/tiki_web/live/admin_live/attendees/show.ex:100
 #: lib/tiki_web/live/admin_live/forms/form.ex:36
 #: lib/tiki_web/live/admin_live/forms/form.ex:159
+#: lib/tiki_web/live/admin_live/orders/show.ex:16
 #: lib/tiki_web/live/admin_live/team/members.ex:60
 #: lib/tiki_web/live/admin_live/team/show.ex:21
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:136
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:135
 #: lib/tiki_web/live/user_live/registration.ex:27
 #, elixir-autogen, elixir-format
 msgid "Email"
@@ -531,7 +529,7 @@ msgid "New batch"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/ticket/index.ex:32
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:187
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:189
 #, elixir-autogen, elixir-format
 msgid "New ticket type"
 msgstr ""
@@ -568,7 +566,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/team/members.ex:71
 #: lib/tiki_web/live/admin_live/team/show.ex:32
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:48
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:102
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:104
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
@@ -593,13 +591,13 @@ msgstr ""
 msgid "Delete batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:104
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:106
 #, elixir-autogen, elixir-format
 msgid "Delete ticket type"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:47
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:101
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:103
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr ""
@@ -609,7 +607,7 @@ msgstr ""
 msgid "Edit batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:186
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit ticket type"
 msgstr ""
@@ -624,13 +622,14 @@ msgstr ""
 msgid "Number of tickets"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:99
+#: lib/tiki_web/live/admin_live/attendees/show.ex:101
+#: lib/tiki_web/live/admin_live/orders/show.ex:17
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:67
 #, elixir-autogen, elixir-format
 msgid "Price"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:88
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:90
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Promo code"
@@ -641,7 +640,7 @@ msgstr ""
 msgid "Purchasable"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:78
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:80
 #, elixir-autogen, elixir-format
 msgid "Purchase deadline"
 msgstr ""
@@ -656,27 +655,27 @@ msgstr ""
 msgid "Save batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:93
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:95
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save ticket type"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:85
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:87
 #, elixir-autogen, elixir-format
 msgid "Ticket batch"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:165
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:167
 #, elixir-autogen, elixir-format
 msgid "Ticket type created successfully"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:143
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:145
 #, elixir-autogen, elixir-format
 msgid "Ticket type deleted successfully"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:152
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:154
 #, elixir-autogen, elixir-format
 msgid "Ticket type updated successfully"
 msgstr ""
@@ -691,12 +690,14 @@ msgstr ""
 msgid "Team"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:59
+#: lib/tiki_web/live/admin_live/orders/show.ex:32
+#: lib/tiki_web/live/admin_live/orders/show.ex:64
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:61
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "Purchase tickets for %{event}. You have %{count} minutes to complete your order."
 msgstr ""
@@ -708,7 +709,7 @@ msgstr ""
 
 #: lib/tiki/orders/order_notifier.ex:115
 #: lib/tiki_web/live/order_live/show.ex:233
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:83
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr ""
@@ -729,12 +730,12 @@ msgstr ""
 msgid "Browse events"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:155
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:114
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Credit card"
 msgstr ""
@@ -746,19 +747,19 @@ msgstr ""
 msgid "Log in"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:170
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:169
 #, elixir-autogen, elixir-format
 msgid "Open swish on this device"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:162
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Pay using Swish"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:160
-#: lib/tiki_web/live/admin_live/attendees/show.ex:202
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:103
+#: lib/tiki_web/live/admin_live/attendees/show.ex:159
+#: lib/tiki_web/live/admin_live/attendees/show.ex:201
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:102
 #, elixir-autogen, elixir-format
 msgid "Payment method"
 msgstr ""
@@ -768,7 +769,7 @@ msgstr ""
 msgid "Read more"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:121
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Swish"
 msgstr ""
@@ -783,12 +784,12 @@ msgstr ""
 msgid "You must accept the terms of service."
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:137
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:136
 #, elixir-autogen, elixir-format
 msgid "Your email"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:130
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:129
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr ""
@@ -884,7 +885,7 @@ msgstr ""
 msgid "Text"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:68
+#: lib/tiki_web/live/admin_live/attendees/show.ex:67
 #, elixir-autogen, elixir-format
 msgid "Attendeee has not filled in the required ticket information"
 msgstr ""
@@ -899,7 +900,8 @@ msgstr ""
 msgid "Billing summary"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:175
+#: lib/tiki_web/live/admin_live/attendees/show.ex:174
+#: lib/tiki_web/live/admin_live/orders/show.ex:40
 #, elixir-autogen, elixir-format
 msgid "Card details"
 msgstr ""
@@ -909,7 +911,7 @@ msgstr ""
 msgid "Contact information"
 msgstr ""
 
-#: lib/tiki_web/live/order_live/ticket.ex:61
+#: lib/tiki_web/live/order_live/ticket.ex:69
 #, elixir-autogen, elixir-format
 msgid "Edit details"
 msgstr ""
@@ -929,24 +931,29 @@ msgstr ""
 msgid "Fill in ticket information"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:95
+#: lib/tiki_web/live/admin_live/attendees/show.ex:91
+#: lib/tiki_web/live/admin_live/orders/show.ex:12
 #, elixir-autogen, elixir-format
 msgid "Information about order."
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/attendees/show.ex:51
-#: lib/tiki_web/live/admin_live/attendees/show.ex:75
+#: lib/tiki_web/live/admin_live/attendees/show.ex:74
 #, elixir-autogen, elixir-format
 msgid "Information about ticket."
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:178
-#: lib/tiki_web/live/admin_live/attendees/show.ex:219
+#: lib/tiki_web/live/admin_live/attendees/show.ex:177
+#: lib/tiki_web/live/admin_live/attendees/show.ex:218
+#: lib/tiki_web/live/admin_live/orders/show.ex:43
+#: lib/tiki_web/live/admin_live/orders/show.ex:75
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:95
+#: lib/tiki_web/live/admin_live/attendees/show.ex:91
+#: lib/tiki_web/live/admin_live/orders/show.ex:12
+#: lib/tiki_web/live/admin_live/orders/show.ex:162
 #, elixir-autogen, elixir-format
 msgid "Order"
 msgstr ""
@@ -956,7 +963,8 @@ msgstr ""
 msgid "Order information"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:96
+#: lib/tiki_web/live/admin_live/attendees/show.ex:92
+#: lib/tiki_web/live/admin_live/orders/show.ex:13
 #, elixir-autogen, elixir-format
 msgid "Order number"
 msgstr ""
@@ -982,13 +990,14 @@ msgstr ""
 msgid "Saved response"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:54
-#: lib/tiki_web/live/admin_live/attendees/show.ex:83
+#: lib/tiki_web/live/admin_live/attendees/show.ex:53
+#: lib/tiki_web/live/admin_live/attendees/show.ex:81
 #, elixir-autogen, elixir-format
 msgid "Signed up at"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:167
+#: lib/tiki_web/live/admin_live/attendees/show.ex:166
+#: lib/tiki_web/live/admin_live/orders/show.ex:37
 #, elixir-autogen, elixir-format
 msgid "Stripe payment reference"
 msgstr ""
@@ -998,7 +1007,8 @@ msgstr ""
 msgid "Subtotal"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:209
+#: lib/tiki_web/live/admin_live/attendees/show.ex:208
+#: lib/tiki_web/live/admin_live/orders/show.ex:69
 #, elixir-autogen, elixir-format
 msgid "Swish payment reference"
 msgstr ""
@@ -1009,26 +1019,28 @@ msgstr ""
 msgid "Thank you for your order!"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:181
-#: lib/tiki_web/live/admin_live/attendees/show.ex:222
+#: lib/tiki_web/live/admin_live/attendees/show.ex:180
+#: lib/tiki_web/live/admin_live/attendees/show.ex:221
+#: lib/tiki_web/live/admin_live/orders/show.ex:46
+#: lib/tiki_web/live/admin_live/orders/show.ex:78
 #: lib/tiki_web/live/order_live/show.ex:143
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the payment method"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/attendees/show.ex:50
-#: lib/tiki_web/live/admin_live/attendees/show.ex:74
+#: lib/tiki_web/live/admin_live/attendees/show.ex:73
 #, elixir-autogen, elixir-format
 msgid "Ticket"
 msgstr ""
 
-#: lib/tiki_web/live/order_live/ticket.ex:44
+#: lib/tiki_web/live/order_live/ticket.ex:52
 #, elixir-autogen, elixir-format
 msgid "Ticket information"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:57
-#: lib/tiki_web/live/admin_live/attendees/show.ex:86
+#: lib/tiki_web/live/admin_live/attendees/show.ex:56
+#: lib/tiki_web/live/admin_live/attendees/show.ex:84
 #, elixir-autogen, elixir-format
 msgid "Ticket type"
 msgstr ""
@@ -1053,8 +1065,8 @@ msgstr ""
 msgid "Your ticket to %{event}"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:61
-#: lib/tiki_web/live/admin_live/attendees/show.ex:79
+#: lib/tiki_web/live/admin_live/attendees/show.ex:60
+#: lib/tiki_web/live/admin_live/attendees/show.ex:78
 #, elixir-autogen, elixir-format
 msgid "View ticket"
 msgstr ""
@@ -1119,7 +1131,7 @@ msgstr ""
 msgid "Organized by"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:191
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:190
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr ""
@@ -1157,12 +1169,12 @@ msgid "Signup form"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:31
-#: lib/tiki_web/live/order_live/ticket.ex:31
 #, elixir-autogen, elixir-format
 msgid "Start time"
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:216
+#: lib/tiki_web/live/admin_live/attendees/show.ex:215
+#: lib/tiki_web/live/admin_live/orders/show.ex:72
 #, elixir-autogen, elixir-format
 msgid "Swish number"
 msgstr ""
@@ -1276,6 +1288,7 @@ msgstr ""
 #: lib/tiki_web/live/admin_live/forms/form.ex:129
 #: lib/tiki_web/live/admin_live/forms/form.ex:150
 #: lib/tiki_web/live/admin_live/forms/index.ex:61
+#: lib/tiki_web/live/admin_live/orders/show.ex:174
 #: lib/tiki_web/live/admin_live/team/form.ex:62
 #: lib/tiki_web/live/admin_live/team/form.ex:80
 #: lib/tiki_web/live/admin_live/team/form.ex:101
@@ -1380,18 +1393,6 @@ msgstr ""
 msgid "Please contact the event organizer if you have any questions."
 msgstr ""
 
-#: lib/tiki_web/live/admin_live/event/form_component.ex:45
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:32
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:38
-#, elixir-autogen, elixir-format
-msgid "In UTC"
-msgstr ""
-
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:79
-#, elixir-autogen, elixir-format
-msgid "In UTC. Leave blank for none"
-msgstr ""
-
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:146
 #, elixir-autogen, elixir-format
 msgid "Sold out"
@@ -1406,11 +1407,6 @@ msgstr ""
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:142
 #, elixir-autogen, elixir-format
 msgid "Ticket releases at"
-msgstr ""
-
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:72
-#, elixir-autogen, elixir-format
-msgid "In UTC. Leave blank to make immediately available"
 msgstr ""
 
 #: lib/tiki_web/live/admin_live/event/form_component.ex:28
@@ -1805,12 +1801,12 @@ msgstr ""
 msgid "Profile updated successfully"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:48
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:50
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Your order was cancelled or has expired. Please try again."
 msgstr ""
@@ -1825,12 +1821,12 @@ msgstr ""
 msgid "Terms"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:145
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:144
 #, elixir-autogen, elixir-format
 msgid "I agree to"
 msgstr ""
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:149
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:148
 #, elixir-autogen, elixir-format
 msgid "the terms of service"
 msgstr ""
@@ -1854,4 +1850,54 @@ msgstr ""
 #: lib/tiki_web/live/order_live/show.ex:41
 #, elixir-autogen, elixir-format
 msgid "View receipt"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:95
+#, elixir-autogen, elixir-format
+msgid "Events and logs"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/event/form_component.ex:45
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:32
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:38
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:81
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone. Leave blank for none"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:73
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone. Leave blank to make immediately available"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:33
+#: lib/tiki_web/live/admin_live/orders/show.ex:65
+#, elixir-autogen, elixir-format
+msgid "Information about payment."
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:36
+#: lib/tiki_web/live/admin_live/orders/show.ex:68
+#, elixir-autogen, elixir-format
+msgid "Payment status"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:35
+#: lib/tiki_web/live/admin_live/orders/show.ex:67
+#, elixir-autogen, elixir-format
+msgid "Payment type"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:14
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:97
+#, elixir-autogen, elixir-format
+msgid "These are all of the order change events that have happened to this order."
 msgstr ""

--- a/priv/gettext/sv/LC_MESSAGES/default.po
+++ b/priv/gettext/sv/LC_MESSAGES/default.po
@@ -108,6 +108,7 @@ msgstr "Inställningar"
 
 #: lib/tiki_web/components/sidebar.ex:102
 #: lib/tiki_web/live/admin_live/attendees/show.ex:102
+#: lib/tiki_web/live/admin_live/orders/show.ex:18
 #: lib/tiki_web/live/admin_live/ticket/index.ex:16
 #: lib/tiki_web/live/admin_live/ticket/index.ex:129
 #: lib/tiki_web/live/order_live/show.ex:46
@@ -144,7 +145,7 @@ msgstr "Datum"
 msgid "Location"
 msgstr "Plats"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:97
+#: lib/tiki_web/live/admin_live/attendees/show.ex:99
 #: lib/tiki_web/live/admin_live/dashboard/index.ex:129
 #: lib/tiki_web/live/admin_live/dashboard/index.ex:153
 #: lib/tiki_web/live/admin_live/event/form_component.ex:22
@@ -153,6 +154,7 @@ msgstr "Plats"
 #: lib/tiki_web/live/admin_live/forms/form.ex:12
 #: lib/tiki_web/live/admin_live/forms/form.ex:158
 #: lib/tiki_web/live/admin_live/forms/index.ex:22
+#: lib/tiki_web/live/admin_live/orders/show.ex:15
 #: lib/tiki_web/live/admin_live/team/form.ex:16
 #: lib/tiki_web/live/admin_live/team/index.ex:23
 #: lib/tiki_web/live/admin_live/team/members.ex:59
@@ -160,7 +162,7 @@ msgstr "Plats"
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:26
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:26
 #: lib/tiki_web/live/order_live/show.ex:73
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:129
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:128
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Namn"
@@ -242,11 +244,6 @@ msgstr "Spara evenemang"
 msgid "Ticket types"
 msgstr "Biljettyper"
 
-#: lib/tiki_web/live/admin_live/attendees/index.ex:75
-#, elixir-autogen, elixir-format
-msgid "New attendee"
-msgstr "Ny besökare"
-
 #: lib/tiki_web/live/admin_live/attendees/index.ex:66
 #, elixir-autogen, elixir-format
 msgid "Search"
@@ -289,7 +286,7 @@ msgstr "Evenemang uppdaterades"
 #: lib/tiki_web/live/admin_live/team/form.ex:22
 #: lib/tiki_web/live/admin_live/team/membership_form.ex:33
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:38
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:92
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:94
 #: lib/tiki_web/live/order_live/ticket_form.ex:42
 #, elixir-autogen, elixir-format
 msgid "Saving..."
@@ -446,12 +443,13 @@ msgid "from last month"
 msgstr "från förra månaden"
 
 #: lib/tiki_web/live/account_live/settings.ex:22
-#: lib/tiki_web/live/admin_live/attendees/show.ex:98
+#: lib/tiki_web/live/admin_live/attendees/show.ex:100
 #: lib/tiki_web/live/admin_live/forms/form.ex:36
 #: lib/tiki_web/live/admin_live/forms/form.ex:159
+#: lib/tiki_web/live/admin_live/orders/show.ex:16
 #: lib/tiki_web/live/admin_live/team/members.ex:60
 #: lib/tiki_web/live/admin_live/team/show.ex:21
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:136
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:135
 #: lib/tiki_web/live/user_live/registration.ex:27
 #, elixir-autogen, elixir-format
 msgid "Email"
@@ -531,7 +529,7 @@ msgid "New batch"
 msgstr "Ny batch"
 
 #: lib/tiki_web/live/admin_live/ticket/index.ex:32
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:187
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:189
 #, elixir-autogen, elixir-format
 msgid "New ticket type"
 msgstr "Ny biljettyp"
@@ -568,7 +566,7 @@ msgstr "Ny biljettyp"
 #: lib/tiki_web/live/admin_live/team/members.ex:71
 #: lib/tiki_web/live/admin_live/team/show.ex:32
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:48
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:102
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:104
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Är du säker?"
@@ -593,13 +591,13 @@ msgstr "Batch uppdaterades"
 msgid "Delete batch"
 msgstr "Ta bort"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:104
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:106
 #, elixir-autogen, elixir-format
 msgid "Delete ticket type"
 msgstr "Ta bort biljettyp"
 
 #: lib/tiki_web/live/admin_live/ticket/batch_form.ex:47
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:101
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:103
 #, elixir-autogen, elixir-format
 msgid "Deleting..."
 msgstr "Tar bort..."
@@ -609,7 +607,7 @@ msgstr "Tar bort..."
 msgid "Edit batch"
 msgstr "Redigera batch"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:186
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit ticket type"
 msgstr "Redigera biljettyp"
@@ -624,13 +622,14 @@ msgstr "Ingen"
 msgid "Number of tickets"
 msgstr "Antal biljetter"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:99
+#: lib/tiki_web/live/admin_live/attendees/show.ex:101
+#: lib/tiki_web/live/admin_live/orders/show.ex:17
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:67
 #, elixir-autogen, elixir-format
 msgid "Price"
 msgstr "Pris"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:88
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:90
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Promo code"
@@ -641,7 +640,7 @@ msgstr "Promokod"
 msgid "Purchasable"
 msgstr "Köpbar"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:78
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:80
 #, elixir-autogen, elixir-format
 msgid "Purchase deadline"
 msgstr "Köpdeadline"
@@ -656,27 +655,27 @@ msgstr "Biljettsläpp"
 msgid "Save batch"
 msgstr "Spara batch"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:93
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:95
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save ticket type"
 msgstr "Spara biljettyp"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:85
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:87
 #, elixir-autogen, elixir-format
 msgid "Ticket batch"
 msgstr "Batch"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:165
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:167
 #, elixir-autogen, elixir-format
 msgid "Ticket type created successfully"
 msgstr "Biljetttypen skapades"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:143
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:145
 #, elixir-autogen, elixir-format
 msgid "Ticket type deleted successfully"
 msgstr "Biljetttypen raderades"
 
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:152
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:154
 #, elixir-autogen, elixir-format
 msgid "Ticket type updated successfully"
 msgstr "Biljetttypen uppdaterades"
@@ -691,12 +690,14 @@ msgstr "Köpta"
 msgid "Team"
 msgstr "Team"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:59
+#: lib/tiki_web/live/admin_live/orders/show.ex:32
+#: lib/tiki_web/live/admin_live/orders/show.ex:64
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "Payment"
 msgstr "Betalning"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:61
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "Purchase tickets for %{event}. You have %{count} minutes to complete your order."
 msgstr "Köp biljetter till %{event}. Du har %{count} minuter på dig att slutföra din beställning."
@@ -708,7 +709,7 @@ msgstr "Måste innehålla @-tecken och inga mellanslag"
 
 #: lib/tiki/orders/order_notifier.ex:115
 #: lib/tiki_web/live/order_live/show.ex:233
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:83
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Total"
 msgstr "Totalt"
@@ -729,12 +730,12 @@ msgstr "Alla evenemang för %{team}"
 msgid "Browse events"
 msgstr "Bläddra bland events"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:155
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Continue"
 msgstr "Fortsätt"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:114
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Credit card"
 msgstr "Kreditkort"
@@ -746,19 +747,19 @@ msgstr "Kreditkort"
 msgid "Log in"
 msgstr "Logga in"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:170
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:169
 #, elixir-autogen, elixir-format
 msgid "Open swish on this device"
 msgstr "Öppna Swish på denna enhet"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:162
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Pay using Swish"
 msgstr "Betala med Swish"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:160
-#: lib/tiki_web/live/admin_live/attendees/show.ex:202
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:103
+#: lib/tiki_web/live/admin_live/attendees/show.ex:159
+#: lib/tiki_web/live/admin_live/attendees/show.ex:201
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:102
 #, elixir-autogen, elixir-format
 msgid "Payment method"
 msgstr "Betalningsmetod"
@@ -768,7 +769,7 @@ msgstr "Betalningsmetod"
 msgid "Read more"
 msgstr "Läs mer"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:121
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Swish"
 msgstr "Swish"
@@ -783,12 +784,12 @@ msgstr "Den sista eventplattformen du behöver"
 msgid "You must accept the terms of service."
 msgstr "Du måste acceptera användarvillkoren."
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:137
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:136
 #, elixir-autogen, elixir-format
 msgid "Your email"
 msgstr "Din epost"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:130
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:129
 #, elixir-autogen, elixir-format
 msgid "Your name"
 msgstr "Ditt namn"
@@ -884,7 +885,7 @@ msgstr "Välj"
 msgid "Text"
 msgstr "Text"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:68
+#: lib/tiki_web/live/admin_live/attendees/show.ex:67
 #, elixir-autogen, elixir-format
 msgid "Attendeee has not filled in the required ticket information"
 msgstr "Besökaren har inte fyllt i obligatorisk biljettinformation"
@@ -899,7 +900,8 @@ msgstr "Tillbaka till din order"
 msgid "Billing summary"
 msgstr "Betalsammanfattning"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:175
+#: lib/tiki_web/live/admin_live/attendees/show.ex:174
+#: lib/tiki_web/live/admin_live/orders/show.ex:40
 #, elixir-autogen, elixir-format
 msgid "Card details"
 msgstr "Kortuppgifter"
@@ -909,7 +911,7 @@ msgstr "Kortuppgifter"
 msgid "Contact information"
 msgstr "Kontaktuppgifter"
 
-#: lib/tiki_web/live/order_live/ticket.ex:61
+#: lib/tiki_web/live/order_live/ticket.ex:69
 #, elixir-autogen, elixir-format
 msgid "Edit details"
 msgstr "Redigera uppgifter"
@@ -929,24 +931,29 @@ msgstr "Fyll i"
 msgid "Fill in ticket information"
 msgstr "Fyll i biljettinformation"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:95
+#: lib/tiki_web/live/admin_live/attendees/show.ex:91
+#: lib/tiki_web/live/admin_live/orders/show.ex:12
 #, elixir-autogen, elixir-format
 msgid "Information about order."
 msgstr "Information om beställningen."
 
 #: lib/tiki_web/live/admin_live/attendees/show.ex:51
-#: lib/tiki_web/live/admin_live/attendees/show.ex:75
+#: lib/tiki_web/live/admin_live/attendees/show.ex:74
 #, elixir-autogen, elixir-format
 msgid "Information about ticket."
 msgstr "Information om biljetten."
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:178
-#: lib/tiki_web/live/admin_live/attendees/show.ex:219
+#: lib/tiki_web/live/admin_live/attendees/show.ex:177
+#: lib/tiki_web/live/admin_live/attendees/show.ex:218
+#: lib/tiki_web/live/admin_live/orders/show.ex:43
+#: lib/tiki_web/live/admin_live/orders/show.ex:75
 #, elixir-autogen, elixir-format
 msgid "Loading..."
 msgstr "Laddar..."
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:95
+#: lib/tiki_web/live/admin_live/attendees/show.ex:91
+#: lib/tiki_web/live/admin_live/orders/show.ex:12
+#: lib/tiki_web/live/admin_live/orders/show.ex:162
 #, elixir-autogen, elixir-format
 msgid "Order"
 msgstr "Beställning"
@@ -956,7 +963,8 @@ msgstr "Beställning"
 msgid "Order information"
 msgstr "Beställningsinformation"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:96
+#: lib/tiki_web/live/admin_live/attendees/show.ex:92
+#: lib/tiki_web/live/admin_live/orders/show.ex:13
 #, elixir-autogen, elixir-format
 msgid "Order number"
 msgstr "Ordernummer"
@@ -982,13 +990,14 @@ msgstr "Betalningsinformation"
 msgid "Saved response"
 msgstr "Sparat svar"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:54
-#: lib/tiki_web/live/admin_live/attendees/show.ex:83
+#: lib/tiki_web/live/admin_live/attendees/show.ex:53
+#: lib/tiki_web/live/admin_live/attendees/show.ex:81
 #, elixir-autogen, elixir-format
 msgid "Signed up at"
 msgstr "Anmälde sig vid"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:167
+#: lib/tiki_web/live/admin_live/attendees/show.ex:166
+#: lib/tiki_web/live/admin_live/orders/show.ex:37
 #, elixir-autogen, elixir-format
 msgid "Stripe payment reference"
 msgstr "Betalningsreferens för Stripe"
@@ -998,7 +1007,8 @@ msgstr "Betalningsreferens för Stripe"
 msgid "Subtotal"
 msgstr "Subtotal"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:209
+#: lib/tiki_web/live/admin_live/attendees/show.ex:208
+#: lib/tiki_web/live/admin_live/orders/show.ex:69
 #, elixir-autogen, elixir-format
 msgid "Swish payment reference"
 msgstr "Betalningsreferens för Swish"
@@ -1009,26 +1019,28 @@ msgstr "Betalningsreferens för Swish"
 msgid "Thank you for your order!"
 msgstr "Tack för din beställning!"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:181
-#: lib/tiki_web/live/admin_live/attendees/show.ex:222
+#: lib/tiki_web/live/admin_live/attendees/show.ex:180
+#: lib/tiki_web/live/admin_live/attendees/show.ex:221
+#: lib/tiki_web/live/admin_live/orders/show.ex:46
+#: lib/tiki_web/live/admin_live/orders/show.ex:78
 #: lib/tiki_web/live/order_live/show.ex:143
 #, elixir-autogen, elixir-format
 msgid "There was an error loading the payment method"
 msgstr "Det gick inte att ladda betalningsmetoden"
 
 #: lib/tiki_web/live/admin_live/attendees/show.ex:50
-#: lib/tiki_web/live/admin_live/attendees/show.ex:74
+#: lib/tiki_web/live/admin_live/attendees/show.ex:73
 #, elixir-autogen, elixir-format
 msgid "Ticket"
 msgstr "Biljett"
 
-#: lib/tiki_web/live/order_live/ticket.ex:44
+#: lib/tiki_web/live/order_live/ticket.ex:52
 #, elixir-autogen, elixir-format
 msgid "Ticket information"
 msgstr "Biljettinformation"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:57
-#: lib/tiki_web/live/admin_live/attendees/show.ex:86
+#: lib/tiki_web/live/admin_live/attendees/show.ex:56
+#: lib/tiki_web/live/admin_live/attendees/show.ex:84
 #, elixir-autogen, elixir-format
 msgid "Ticket type"
 msgstr "Biljettyp"
@@ -1053,8 +1065,8 @@ msgstr "Du måste fylla i information för denna biljett"
 msgid "Your ticket to %{event}"
 msgstr "Din biljett till %{event}"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:61
-#: lib/tiki_web/live/admin_live/attendees/show.ex:79
+#: lib/tiki_web/live/admin_live/attendees/show.ex:60
+#: lib/tiki_web/live/admin_live/attendees/show.ex:78
 #, elixir-autogen, elixir-format
 msgid "View ticket"
 msgstr "Visa biljett"
@@ -1119,7 +1131,7 @@ msgstr "Inga biljettbatchar"
 msgid "Organized by"
 msgstr "Organiseras av"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:191
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:190
 #, elixir-autogen, elixir-format
 msgid "Pay"
 msgstr "Betala"
@@ -1157,12 +1169,12 @@ msgid "Signup form"
 msgstr "Anmälningsformulär"
 
 #: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:31
-#: lib/tiki_web/live/order_live/ticket.ex:31
 #, elixir-autogen, elixir-format
 msgid "Start time"
 msgstr "Starttid"
 
-#: lib/tiki_web/live/admin_live/attendees/show.ex:216
+#: lib/tiki_web/live/admin_live/attendees/show.ex:215
+#: lib/tiki_web/live/admin_live/orders/show.ex:72
 #, elixir-autogen, elixir-format
 msgid "Swish number"
 msgstr "Swish-nummer"
@@ -1276,6 +1288,7 @@ msgstr "Ladda upp en fil"
 #: lib/tiki_web/live/admin_live/forms/form.ex:129
 #: lib/tiki_web/live/admin_live/forms/form.ex:150
 #: lib/tiki_web/live/admin_live/forms/index.ex:61
+#: lib/tiki_web/live/admin_live/orders/show.ex:174
 #: lib/tiki_web/live/admin_live/team/form.ex:62
 #: lib/tiki_web/live/admin_live/team/form.ex:80
 #: lib/tiki_web/live/admin_live/team/form.ex:101
@@ -1380,18 +1393,6 @@ msgstr "Inga biljetter tillgängliga"
 msgid "Please contact the event organizer if you have any questions."
 msgstr "Kontakta evenemangets arrangör om du har några frågor."
 
-#: lib/tiki_web/live/admin_live/event/form_component.ex:45
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:32
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:38
-#, elixir-autogen, elixir-format
-msgid "In UTC"
-msgstr "I UTC"
-
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:79
-#, elixir-autogen, elixir-format
-msgid "In UTC. Leave blank for none"
-msgstr "I UTC. Lämna tomt för ingen"
-
 #: lib/tiki_web/live/purchase_live/tickets_component.ex:146
 #, elixir-autogen, elixir-format
 msgid "Sold out"
@@ -1407,11 +1408,6 @@ msgstr "Biljetten inte tillgänglig"
 #, elixir-autogen, elixir-format
 msgid "Ticket releases at"
 msgstr "Biljett släpps vid"
-
-#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:72
-#, elixir-autogen, elixir-format
-msgid "In UTC. Leave blank to make immediately available"
-msgstr "I UTC. Lämna tomt för att göra tillgänglig direkt"
 
 #: lib/tiki_web/live/admin_live/event/form_component.ex:28
 #, elixir-autogen, elixir-format
@@ -1805,12 +1801,12 @@ msgstr "Om adressen finns i systemet så skickas instruktioner för att logga in
 msgid "Profile updated successfully"
 msgstr "Profil uppdaterades"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:48
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr "Fel"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:50
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Something went wrong. Your order was cancelled or has expired. Please try again."
 msgstr "Något gick fel. Din beställning är avbruten eller har gått ut. Vänligen försök igen."
@@ -1825,12 +1821,12 @@ msgstr "Aktivera"
 msgid "Terms"
 msgstr "Villkor"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:145
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:144
 #, elixir-autogen, elixir-format
 msgid "I agree to"
 msgstr "Jag godkänner"
 
-#: lib/tiki_web/live/purchase_live/purchase_component.ex:149
+#: lib/tiki_web/live/purchase_live/purchase_component.ex:148
 #, elixir-autogen, elixir-format
 msgid "the terms of service"
 msgstr "köp och leveransvillkoren"
@@ -1855,3 +1851,53 @@ msgstr "Köpdatum"
 #, elixir-autogen, elixir-format
 msgid "View receipt"
 msgstr "Kvitto"
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:95
+#, elixir-autogen, elixir-format
+msgid "Events and logs"
+msgstr "Event och loggar"
+
+#: lib/tiki_web/live/admin_live/event/form_component.ex:45
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:32
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:38
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone"
+msgstr "I tidszonen 'Europe/Stockholm'"
+
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:81
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone. Leave blank for none"
+msgstr "I tidszonen 'Europe/Stockholm'. Lämna tomt för ingen"
+
+#: lib/tiki_web/live/admin_live/ticket/ticket_type_form.ex:73
+#, elixir-autogen, elixir-format
+msgid "In 'Europe/Stockholm' timezone. Leave blank to make immediately available"
+msgstr ""
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:33
+#: lib/tiki_web/live/admin_live/orders/show.ex:65
+#, elixir-autogen, elixir-format
+msgid "Information about payment."
+msgstr "Information om betalningen"
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:36
+#: lib/tiki_web/live/admin_live/orders/show.ex:68
+#, elixir-autogen, elixir-format
+msgid "Payment status"
+msgstr "Betalningsstatus"
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:35
+#: lib/tiki_web/live/admin_live/orders/show.ex:67
+#, elixir-autogen, elixir-format
+msgid "Payment type"
+msgstr "Betalmetod"
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:14
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr "Status"
+
+#: lib/tiki_web/live/admin_live/orders/show.ex:97
+#, elixir-autogen, elixir-format
+msgid "These are all of the order change events that have happened to this order."
+msgstr "Alla events och ändringar av beställningen"

--- a/test/support/fixtures/events_fixtures.ex
+++ b/test/support/fixtures/events_fixtures.ex
@@ -14,7 +14,7 @@ defmodule Tiki.EventsFixtures do
       attrs
       |> Enum.into(%{
         description: "some description",
-        event_date: ~U[2023-03-25 16:55:00Z],
+        event_date: ~U[2023-03-25 16:55:00Z] |> DateTime.shift_zone!("Europe/Stockholm"),
         name: "some name",
         team_id: team.id,
         is_hidden: false


### PR DESCRIPTION
Makes the system less confusing for admins. Timestamps are still stored in UTC in the database but datetime-form inputs are assumed to be in Europe/Stockholm.