### PR TITLE
Default form and QOL fixes

### DIFF
--- a/lib/tiki/accounts/user.ex
+++ b/lib/tiki/accounts/user.ex
@@ -12,8 +12,6 @@ defmodule Tiki.Accounts.User do
     field :confirmed_at, :naive_datetime
 
     field :locale, :string, default: "en"
-    # TODO: Change to :user
-    field :role, Ecto.Enum, values: [:user, :admin], default: :admin
 
     has_many :memberships, Tiki.Teams.Membership
 
@@ -52,7 +50,7 @@ defmodule Tiki.Accounts.User do
   """
   def registration_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, [:email, :kth_id, :role, :first_name, :last_name, :locale])
+    |> cast(attrs, [:email, :kth_id, :first_name, :last_name, :locale])
     |> validate_email(opts)
   end
 
@@ -63,7 +61,7 @@ defmodule Tiki.Accounts.User do
   """
   def email_changeset(user, attrs, opts \\ []) do
     user
-    |> cast(attrs, [:email, :kth_id, :role, :first_name, :last_name, :locale])
+    |> cast(attrs, [:email, :kth_id, :first_name, :last_name, :locale])
     |> validate_email(opts)
     |> case do
       %{changes: %{email: _}} = changeset -> changeset

--- a/lib/tiki/policy/checks.ex
+++ b/lib/tiki/policy/checks.ex
@@ -3,9 +3,6 @@ defmodule Tiki.Policy.Checks do
   alias Tiki.Teams
   alias Tiki.Events
 
-  def role(%Accounts.User{role: role}, _object, role), do: true
-  def role(_, _, _), do: false
-
   def pls(%Accounts.User{} = user, _object, permission) do
     Tiki.Pls.get_permissions(user)
     |> Enum.any?(fn p -> p == permission end)

--- a/lib/tiki_web/components/sidebar.ex
+++ b/lib/tiki_web/components/sidebar.ex
@@ -269,6 +269,15 @@ defmodule TikiWeb.Component.Sidebar do
                 <.menu_shortcut>⌘N</.menu_shortcut>
               </.menu_item>
             </.link>
+
+            <.link
+              :if={Tiki.Policy.authorize?(:tiki_admin, @current_user)}
+              navigate={~p"/admin/clear_team"}
+            >
+              <.menu_item class="hover:cursor-pointer">
+                <span>Admin: Clear team</span>
+              </.menu_item>
+            </.link>
           </.menu_group>
         </.menu>
       </.dropdown_menu_content>

--- a/lib/tiki_web/live/admin_live/dashboard/team.ex
+++ b/lib/tiki_web/live/admin_live/dashboard/team.ex
@@ -63,7 +63,13 @@ defmodule TikiWeb.AdminLive.Dashboard.Team do
     if socket.assigns.current_team do
       {:ok, redirect(socket, to: ~p"/admin")}
     else
-      teams = Teams.get_teams_for_user(socket.assigns.current_user.id)
+      # Fetch all teams for admins, so that they easier can view stuff for teams where
+      # they are not members.
+      teams =
+        case Tiki.Policy.authorize?(:tiki_admin, socket.assigns.current_user) do
+          true -> Teams.list_teams()
+          false -> Teams.get_teams_for_user(socket.assigns.current_user.id)
+        end
 
       {:ok,
        socket

--- a/lib/tiki_web/live/admin_live/event/form_component.ex
+++ b/lib/tiki_web/live/admin_live/event/form_component.ex
@@ -30,6 +30,7 @@ defmodule TikiWeb.AdminLive.Event.FormComponent do
         />
 
         <.input
+          :if={@action == :edit}
           field={@form[:default_form_id]}
           type="select"
           label={gettext("Default signup form")}
@@ -89,7 +90,7 @@ defmodule TikiWeb.AdminLive.Event.FormComponent do
     |> assign_form(changeset)
   end
 
-  defp apply_action(socket, :edit, event) do
+  defp apply_action(socket, existing, event) when existing in [:edit, :delete] do
     changeset = Events.change_event(event)
     forms = Tiki.Forms.list_forms_for_event(event.id)
 

--- a/lib/tiki_web/live/admin_live/ticket/index.ex
+++ b/lib/tiki_web/live/admin_live/ticket/index.ex
@@ -163,10 +163,15 @@ defmodule TikiWeb.AdminLive.Ticket.Index do
   end
 
   def apply_action(socket, :new_ticket_type, params) do
+    start_time = socket.assigns.event.event_date
+
     ticket_type =
       case params do
-        %{"batch_id" => batch_id} -> %TicketType{ticket_batch_id: batch_id}
-        _ -> %TicketType{}
+        %{"batch_id" => batch_id} ->
+          %TicketType{ticket_batch_id: batch_id, start_time: start_time}
+
+        _ ->
+          %TicketType{start_time: start_time}
       end
 
     socket

--- a/lib/tiki_web/user_auth.ex
+++ b/lib/tiki_web/user_auth.ex
@@ -213,35 +213,6 @@ defmodule TikiWeb.UserAuth do
     end
   end
 
-  def on_mount(:ensure_admin, _params, session, socket) do
-    socket = mount_current_user(session, socket)
-
-    if socket.assigns.current_user do
-      case socket.assigns.current_user.role do
-        :admin ->
-          {:cont, socket}
-
-        _ ->
-          socket =
-            socket
-            |> Phoenix.LiveView.put_flash(
-              :error,
-              gettext("You need to be an admin to access this page.")
-            )
-            |> Phoenix.LiveView.redirect(to: ~p"/users/log_in")
-
-          {:halt, socket}
-      end
-    else
-      socket =
-        socket
-        |> Phoenix.LiveView.put_flash(:error, gettext("You must log in to access this page."))
-        |> Phoenix.LiveView.redirect(to: ~p"/users/log_in")
-
-      {:halt, socket}
-    end
-  end
-
   def on_mount({:authorize, action}, _params, _session, socket) do
     with %Accounts.User{} = user <- socket.assigns.current_user,
          :ok <- Tiki.Policy.authorize(action, user) do

--- a/priv/repo/migrations/20250417215347_allow_event_deletion.exs
+++ b/priv/repo/migrations/20250417215347_allow_event_deletion.exs
@@ -1,0 +1,68 @@
+defmodule Tiki.Repo.Migrations.AllowEventDeletion do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER TABLE forms DROP CONSTRAINT forms_event_id_fkey"
+    execute "ALTER TABLE form_questions DROP CONSTRAINT form_questions_form_id_fkey"
+    execute "ALTER TABLE form_responses DROP CONSTRAINT form_responses_form_id_fkey"
+
+    execute "ALTER TABLE form_question_responses DROP CONSTRAINT form_question_responses_response_id_fkey"
+
+    execute "ALTER TABLE form_question_responses DROP CONSTRAINT form_question_responses_question_id_fkey"
+
+    execute "ALTER TABLE ticket_batches DROP CONSTRAINT ticket_batches_event_id_fkey"
+
+    alter table(:forms) do
+      modify :event_id, references(:events, type: :binary_id, on_delete: :delete_all)
+    end
+
+    alter table(:form_questions) do
+      modify :form_id, references(:forms, on_delete: :delete_all)
+    end
+
+    alter table(:form_responses) do
+      modify :form_id, references(:forms, on_delete: :delete_all)
+    end
+
+    alter table(:form_question_responses) do
+      modify :response_id, references(:form_responses, on_delete: :delete_all)
+      modify :question_id, references(:form_questions, on_delete: :delete_all)
+    end
+
+    alter table(:ticket_batches) do
+      modify :event_id, references(:events, type: :binary_id, on_delete: :nilify_all)
+    end
+  end
+
+  def down do
+    execute "ALTER TABLE forms DROP CONSTRAINT forms_event_id_fkey"
+    execute "ALTER TABLE form_questions DROP CONSTRAINT form_questions_form_id_fkey"
+    execute "ALTER TABLE form_responses DROP CONSTRAINT form_responses_form_id_fkey"
+    execute "ALTER TABLE ticket_batches DROP CONSTRAINT ticket_batches_event_id_fkey"
+
+    execute "ALTER TABLE form_question_responses DROP CONSTRAINT form_question_responses_response_id_fkey"
+
+    execute "ALTER TABLE form_question_responses DROP CONSTRAINT form_question_responses_question_id_fkey"
+
+    alter table(:forms) do
+      modify :event_id, references(:events, type: :binary_id)
+    end
+
+    alter table(:form_questions) do
+      modify :form_id, references(:forms)
+    end
+
+    alter table(:form_responses) do
+      modify :form_id, references(:forms)
+    end
+
+    alter table(:form_question_responses) do
+      modify :response_id, references(:form_responses)
+      modify :question_id, references(:form_questions)
+    end
+
+    alter table(:ticket_batches) do
+      modify :event_id, references(:events, type: :binary_id, on_delete: :nothing)
+    end
+  end
+end

--- a/test/tiki/events_test.exs
+++ b/test/tiki/events_test.exs
@@ -68,6 +68,21 @@ defmodule Tiki.EventsTest do
       assert event.description == "some description"
       assert event.event_date == ~U[2023-03-25 16:55:00Z]
       assert event.name == "some name"
+
+      # Assert that we have a default form
+
+      assert event.default_form_id != nil
+
+      form = Tiki.Forms.get_form!(event.default_form_id)
+
+      assert form.event_id == event.id
+      assert form.name =~ "Default form"
+      assert form.description =~ "We need some information to organize our event"
+
+      assert [
+               %{name: "Name", required: true, type: :attendee_name},
+               %{name: "Email", required: true, type: :email}
+             ] = form.questions
     end
 
     test "create_event/1 with invalid data returns error changeset" do

--- a/test/tiki/forms_test.exs
+++ b/test/tiki/forms_test.exs
@@ -6,7 +6,7 @@ defmodule Tiki.FormsTest do
 
     test "list_forms_for_event/1 returns all forms" do
       form = form_fixture()
-      assert Tiki.Forms.list_forms_for_event(form.event_id) == [form]
+      assert form in Tiki.Forms.list_forms_for_event(form.event_id)
     end
 
     test "create_form/1 with valid data creates a form" do

--- a/test/tiki/orders_test.exs
+++ b/test/tiki/orders_test.exs
@@ -71,6 +71,8 @@ defmodule Tiki.OrdersTest do
     test "list_orders_for_event/1 returns all orders for a given event" do
       event = Tiki.EventsFixtures.event_fixture()
 
+      :rand.seed(:exs64, {1, 1, 2})
+
       orders =
         Enum.map(1..5, fn _ ->
           status = Enum.random(Ecto.Enum.dump_values(Orders.Order, :status))


### PR DESCRIPTION
* Automatically create a default form when an event is created, closes #69.
* Prefill ticket start time to event time, closes #65
* Change cascade rules so events can be deleted
* Fixed a bug where stats would not load for events with zero orders