### PR TITLE
Fix/upload UUID

### DIFF
--- a/lib/tiki/s3.ex
+++ b/lib/tiki/s3.ex
@@ -5,7 +5,7 @@ defmodule Tiki.S3 do
   end
 
   def presign_form(entry) do
-    options = Keyword.merge(get_options(entry.client_name), content_type: entry.client_type)
+    options = Keyword.merge(get_options(entry.uuid), content_type: entry.client_type)
     ReqS3.presign_form(options)
   end
 

--- a/lib/tiki_web/components/core_components.ex
+++ b/lib/tiki_web/components/core_components.ex
@@ -373,7 +373,7 @@ defmodule TikiWeb.CoreComponents do
           <span class="text-foreground text-sm font-semibold">{entry.client_name}</span>
           <div class="text-muted-foreground text-sm">
             {entry.progress}%
-            <.link :if={entry.done?} href={Tiki.S3.presign_url(entry.client_name)}>
+            <.link :if={entry.done?} href={Tiki.S3.presign_url(entry.uuid)}>
               {gettext("uploaded")}
             </.link>
           </div>

--- a/lib/tiki_web/live/admin_live/event/form_component.ex
+++ b/lib/tiki_web/live/admin_live/event/form_component.ex
@@ -152,7 +152,7 @@ defmodule TikiWeb.AdminLive.Event.FormComponent do
 
     case completed do
       [] -> params
-      [image | _] -> Map.put(params, "image_url", "uploads/#{image.client_name}")
+      [image | _] -> Map.put(params, "image_url", "uploads/#{image.uuid}")
     end
   end
 
@@ -171,7 +171,7 @@ defmodule TikiWeb.AdminLive.Event.FormComponent do
 
     meta = %{
       uploader: "S3",
-      key: "uploads/#{entry.client_name}",
+      key: "uploads/#{entry.uuid}",
       url: form.url,
       fields: Map.new(form.fields)
     }

--- a/lib/tiki_web/live/admin_live/team/form.ex
+++ b/lib/tiki_web/live/admin_live/team/form.ex
@@ -145,7 +145,7 @@ defmodule TikiWeb.AdminLive.Team.Form do
 
     case completed do
       [] -> params
-      [image | _] -> Map.put(params, "logo_url", "uploads/#{image.client_name}")
+      [image | _] -> Map.put(params, "logo_url", "uploads/#{image.uuid}")
     end
   end
 
@@ -154,7 +154,7 @@ defmodule TikiWeb.AdminLive.Team.Form do
 
     meta = %{
       uploader: "S3",
-      key: "uploads/#{entry.client_name}",
+      key: "uploads/#{entry.uuid}",
       url: form.url,
       fields: Map.new(form.fields)
     }

--- a/remote.sh
+++ b/remote.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+STATUS=$(nomad job inspect -namespace=metaspexet tiki 2>&1)
+
+if [[ $STATUS == Error* ]]; then
+    SECRET_ID=$(nomad login | grep "Secret ID" | sed -E "s/.*= *(.+)/\\1/")
+    sed -i '' "s/^export NOMAD_TOKEN=.*/export NOMAD_TOKEN=$SECRET_ID/" .env
+    export NOMAD_TOKEN=$SECRET_ID
+fi
+
+ALLOCATION_ID=$(nomad job allocs -namespace=metaspexet tiki | awk 'NR==2 {print $1}')
+nomad exec -namespace metaspexet -task tiki $ALLOCATION_ID /app/bin/tiki remote


### PR DESCRIPTION
Generate uuid for file upload names, to avoid naming conflicts, and wierd characters that AWS does not like (such as : ). PS. we could also url-encode client names but this is simplter.