### PR TITLE
Add promo codes to uri params

### DIFF
--- a/lib/tiki_web/live/event_live/show.ex
+++ b/lib/tiki_web/live/event_live/show.ex
@@ -58,6 +58,7 @@ defmodule TikiWeb.EventLive.Show do
             current_user={@current_user}
             event={@event}
             order={@order}
+            promo_codes={@promo_codes}
           />
         </div>
       </div>
@@ -121,7 +122,15 @@ defmodule TikiWeb.EventLive.Show do
 
   @impl true
   def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+    promo_codes =
+      case Map.get(params, "promo_codes", []) do
+        codes when is_list(codes) -> codes
+        _ -> []
+      end
+
+    {:noreply,
+     apply_action(socket, socket.assigns.live_action, params)
+     |> assign(promo_codes: promo_codes)}
   end
 
   def apply_action(socket, :index, _params) do

--- a/lib/tiki_web/live/purchase_live/tickets_component.ex
+++ b/lib/tiki_web/live/purchase_live/tickets_component.ex
@@ -173,7 +173,7 @@ defmodule TikiWeb.PurchaseLive.TicketsComponent do
      |> assign(assigns)
      |> assign(
        promo_code: "",
-       promo_codes: [],
+       promo_codes: Map.get(assigns, :promo_codes, []),
        error: nil
      )
      |> assign_ticket_types(get_available_ticket_types(event.id))}
@@ -237,8 +237,11 @@ defmodule TikiWeb.PurchaseLive.TicketsComponent do
     with {:ok, order} <- Orders.reserve_tickets(event_id, to_purchase) do
       to =
         case socket.assigns[:embedded] do
-          nil -> ~p"/events/#{event_id}/purchase/#{order}"
-          true -> ~p"/embed/events/#{event_id}/purchase/#{order}"
+          nil ->
+            ~p"/events/#{event_id}/purchase/#{order}?#{%{"promo_codes" => socket.assigns.promo_codes}}"
+
+          true ->
+            ~p"/embed/events/#{event_id}/purchase/#{order}"
         end
 
       {:noreply, push_navigate(socket, to: to)}


### PR DESCRIPTION
Adds the option of applying promo codes via url parameters, eg. `https://tiki.datasektionen.se/events/<event_id>?promo_codes[]=secret&promo_codes[]=other_code`