### PR TITLE
Migrate/139/rfinger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     mix archive.install hex phx_new --force && \
     mix local.rebar --force
 
-RUN apt-get install -y nginx
+RUN apt-get install -y nginx gpg
 
 # Add stripe CLI
 RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor | tee /usr/share/keyrings/stripe.gpg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,8 +155,10 @@ configs:
       users:
         - kth_id: turetek
           email: turetek@kth.se
-          first_name: Ture
+          first_name: Tusre
           family_name: Teknolog
+          picture: https://thskth.se/wp-content/uploads/2023/06/ths-logo-bla-01-300x294-1.png
+          thumbnail: https://thskth.se/wp-content/uploads/2019/12/ths-logo-svart-01.png
         - kth_id: money
           email: money@kth.se
           first_name: Lucas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ configs:
       users:
         - kth_id: turetek
           email: turetek@kth.se
-          first_name: Tusre
+          first_name: Ture
           family_name: Teknolog
           picture: https://thskth.se/wp-content/uploads/2023/06/ths-logo-bla-01-300x294-1.png
           thumbnail: https://thskth.se/wp-content/uploads/2019/12/ths-logo-svart-01.png

--- a/lib/tiki/accounts.ex
+++ b/lib/tiki/accounts.ex
@@ -136,9 +136,8 @@ defmodule Tiki.Accounts do
   def link_user_with_userinfo(user, %{"kth_id" => id} = attrs) do
     case Repo.get_by(User, kth_id: id) do
       nil ->
-        # Include kth_id, year_tag and picture_url if present
-        link_attrs = Map.take(attrs, ["kth_id", "year_tag", "picture_url"])
-
+        # Include kth_id and year_tag if present
+        link_attrs = Map.take(attrs, ["kth_id", "year_tag"])
         User.oidcc_changeset(user, link_attrs)
         |> Repo.update()
 

--- a/lib/tiki/accounts.ex
+++ b/lib/tiki/accounts.ex
@@ -123,6 +123,7 @@ defmodule Tiki.Accounts do
         |> Repo.insert()
 
       user ->
+        user = Map.put(user, :picture_url, attrs["picture_url"])
         {:ok, user}
     end
   end
@@ -135,8 +136,7 @@ defmodule Tiki.Accounts do
   def link_user_with_userinfo(user, %{"kth_id" => id} = attrs) do
     case Repo.get_by(User, kth_id: id) do
       nil ->
-        # Include kth_id and year_tag if present
-        link_attrs = Map.take(attrs, ["kth_id", "year_tag"])
+        link_attrs = Map.take(attrs, ["kth_id", "year_tag", "picture_url"])
 
         User.oidcc_changeset(user, link_attrs)
         |> Repo.update()

--- a/lib/tiki/accounts.ex
+++ b/lib/tiki/accounts.ex
@@ -138,6 +138,7 @@ defmodule Tiki.Accounts do
       nil ->
         # Include kth_id and year_tag if present
         link_attrs = Map.take(attrs, ["kth_id", "year_tag"])
+
         User.oidcc_changeset(user, link_attrs)
         |> Repo.update()
 

--- a/lib/tiki/accounts.ex
+++ b/lib/tiki/accounts.ex
@@ -136,6 +136,7 @@ defmodule Tiki.Accounts do
   def link_user_with_userinfo(user, %{"kth_id" => id} = attrs) do
     case Repo.get_by(User, kth_id: id) do
       nil ->
+        # Include kth_id, year_tag and picture_url if present
         link_attrs = Map.take(attrs, ["kth_id", "year_tag", "picture_url"])
 
         User.oidcc_changeset(user, link_attrs)

--- a/lib/tiki/accounts.ex
+++ b/lib/tiki/accounts.ex
@@ -123,8 +123,15 @@ defmodule Tiki.Accounts do
         |> Repo.insert()
 
       user ->
+        {:ok, user}
+    end
+    |> case do
+      {:ok, user} ->
         user = Map.put(user, :picture_url, attrs["picture_url"])
         {:ok, user}
+
+      changeset ->
+        changeset
     end
   end
 

--- a/lib/tiki/accounts/user.ex
+++ b/lib/tiki/accounts/user.ex
@@ -14,7 +14,7 @@ defmodule Tiki.Accounts.User do
     field :confirmed_at, :naive_datetime
 
     field :locale, :string, default: "en"
-    
+
     field :picture_url, :string, virtual: true
     has_many :memberships, Tiki.Teams.Membership
 

--- a/lib/tiki/accounts/user.ex
+++ b/lib/tiki/accounts/user.ex
@@ -23,7 +23,7 @@ defmodule Tiki.Accounts.User do
 
   def oidcc_changeset(user, attrs) do
     user
-    |> cast(attrs, [:kth_id, :year_tag, :email, :first_name, :last_name, :picture_url])
+    |> cast(attrs, [:kth_id, :year_tag, :email, :first_name, :last_name])
     |> validate_required([:kth_id, :email])
     |> unsafe_validate_unique(:email, Tiki.Repo)
     |> unique_constraint(:email)

--- a/lib/tiki/accounts/user.ex
+++ b/lib/tiki/accounts/user.ex
@@ -14,7 +14,8 @@ defmodule Tiki.Accounts.User do
     field :confirmed_at, :naive_datetime
 
     field :locale, :string, default: "en"
-
+    
+    field :picture_url, :string, virtual: true
     has_many :memberships, Tiki.Teams.Membership
 
     timestamps()
@@ -22,7 +23,7 @@ defmodule Tiki.Accounts.User do
 
   def oidcc_changeset(user, attrs) do
     user
-    |> cast(attrs, [:kth_id, :year_tag, :email, :first_name, :last_name])
+    |> cast(attrs, [:kth_id, :year_tag, :email, :first_name, :last_name, :picture_url])
     |> validate_required([:kth_id, :email])
     |> unsafe_validate_unique(:email, Tiki.Repo)
     |> unique_constraint(:email)

--- a/lib/tiki_web/components/sidebar.ex
+++ b/lib/tiki_web/components/sidebar.ex
@@ -329,7 +329,7 @@ defmodule TikiWeb.Component.Sidebar do
         <.dropdown_menu_trigger>
           <button class="flex w-full flex-row items-center gap-2 rounded-md p-2 hover:bg-accent">
             <img
-              src={"https://zfinger.datasektionen.se/user/#{@current_user.kth_id}/image/100"}
+              src={"#{@current_user.picture_url}"}
               class="fill-primary-foreground h-8 w-8 rounded-lg object-cover"
             />
             <div class="grid flex-1 text-left text-sm leading-tight">
@@ -344,7 +344,7 @@ defmodule TikiWeb.Component.Sidebar do
             <.menu_label>
               <div class="inline-flex gap-2">
                 <img
-                  src={"https://zfinger.datasektionen.se/user/#{@current_user.kth_id}/image/100"}
+                  src={"#{@current_user.picture_url}"}
                   class="fill-primary-foreground h-8 w-8 rounded-lg object-cover"
                 />
                 <div class="grid flex-1 text-left text-sm leading-tight">

--- a/lib/tiki_web/components/sidebar.ex
+++ b/lib/tiki_web/components/sidebar.ex
@@ -329,6 +329,7 @@ defmodule TikiWeb.Component.Sidebar do
         <.dropdown_menu_trigger>
           <button class="flex w-full flex-row items-center gap-2 rounded-md p-2 hover:bg-accent">
             <img
+              :if={@current_user.picture_url}
               src={"#{@current_user.picture_url}"}
               class="fill-primary-foreground h-8 w-8 rounded-lg object-cover"
             />
@@ -344,6 +345,7 @@ defmodule TikiWeb.Component.Sidebar do
             <.menu_label>
               <div class="inline-flex gap-2">
                 <img
+                  :if={@current_user.picture_url}
                   src={"#{@current_user.picture_url}"}
                   class="fill-primary-foreground h-8 w-8 rounded-lg object-cover"
                 />

--- a/lib/tiki_web/controllers/oidcc_controller.ex
+++ b/lib/tiki_web/controllers/oidcc_controller.ex
@@ -8,7 +8,8 @@ defmodule TikiWeb.OidccController do
   @key_replacements %{
     "sub" => "kth_id",
     "given_name" => "first_name",
-    "family_name" => "last_name"
+    "family_name" => "last_name",
+    "picture" => "picture_url"
   }
 
   plug(
@@ -18,7 +19,7 @@ defmodule TikiWeb.OidccController do
       client_id: &__MODULE__.client_id/0,
       client_secret: &__MODULE__.client_secret/0,
       redirect_uri: &__MODULE__.callback_uri/0,
-      scopes: ["openid", "profile", "email", "year_tag"]
+      scopes: ["openid", "profile", "email", "year_tag", "picture"]
     ]
     when action in [:authorize]
   )
@@ -56,7 +57,7 @@ defmodule TikiWeb.OidccController do
         %Plug.Conn{private: %{Oidcc.Plug.AuthorizationCallback => {:ok, {_token, userinfo}}}} =
           conn,
         _params
-      ) do
+      ) do        
     userinfo =
       Map.new(userinfo, fn {k, v} ->
         key = Map.get(@key_replacements, k, k)

--- a/lib/tiki_web/controllers/oidcc_controller.ex
+++ b/lib/tiki_web/controllers/oidcc_controller.ex
@@ -57,7 +57,7 @@ defmodule TikiWeb.OidccController do
         %Plug.Conn{private: %{Oidcc.Plug.AuthorizationCallback => {:ok, {_token, userinfo}}}} =
           conn,
         _params
-      ) do        
+      ) do
     userinfo =
       Map.new(userinfo, fn {k, v} ->
         key = Map.get(@key_replacements, k, k)

--- a/lib/tiki_web/user_auth.ex
+++ b/lib/tiki_web/user_auth.ex
@@ -36,7 +36,7 @@ defmodule TikiWeb.UserAuth do
     conn
     |> renew_session()
     |> put_token_in_session(token)
-    |> put_session(:picture_url, user.picture_url)
+    |> put_user_picture_in_session(user)
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: user_return_to || signed_in_path(conn))
   end
@@ -96,7 +96,10 @@ defmodule TikiWeb.UserAuth do
   def fetch_current_user(conn, _opts) do
     {user_token, conn} = ensure_user_token(conn)
 
-    user = user_token && Accounts.get_user_by_session_token(user_token)
+    user =
+      user_token &&
+        Accounts.get_user_by_session_token(user_token)
+        |> assign_user_picture_from_session(get_session(conn))
 
     team =
       case get_session(conn, :current_team_id) do
@@ -304,14 +307,8 @@ defmodule TikiWeb.UserAuth do
     end)
     |> Phoenix.Component.assign_new(:current_user, fn ->
       if user_token = session["user_token"] do
-        user = Accounts.get_user_by_session_token(user_token)
-        picture_url = session["picture_url"]
-
-        if user && picture_url do
-          Map.put(user, :picture_url, picture_url)
-        else
-          user
-        end
+        Accounts.get_user_by_session_token(user_token)
+        |> assign_user_picture_from_session(session)
       end
     end)
     |> Phoenix.Component.assign_new(:current_team, fn ->
@@ -399,6 +396,21 @@ defmodule TikiWeb.UserAuth do
     |> put_session(:user_token, token)
     |> put_session(:live_socket_id, "users_sessions:#{Base.url_encode64(token)}")
   end
+
+  defp put_user_picture_in_session(conn, user) do
+    put_session(conn, :picture_url, user.picture_url)
+  end
+
+  defp assign_user_picture_from_session(%Accounts.User{} = user, session) do
+    picture_url = session["picture_url"]
+
+    case picture_url do
+      nil -> user
+      picture -> Map.put(user, :picture_url, picture)
+    end
+  end
+
+  defp assign_user_picture_from_session(user, _session), do: user
 
   defp maybe_store_return_to(%{method: "GET"} = conn) do
     put_session(conn, :user_return_to, current_path(conn))

--- a/lib/tiki_web/user_auth.ex
+++ b/lib/tiki_web/user_auth.ex
@@ -36,6 +36,7 @@ defmodule TikiWeb.UserAuth do
     conn
     |> renew_session()
     |> put_token_in_session(token)
+    |> put_session(:picture_url, user.picture_url)
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: user_return_to || signed_in_path(conn))
   end
@@ -96,6 +97,17 @@ defmodule TikiWeb.UserAuth do
     {user_token, conn} = ensure_user_token(conn)
 
     user = user_token && Accounts.get_user_by_session_token(user_token)
+
+    picture_url = get_session(conn, :picture_url)
+
+    user =
+      if user && picture_url do
+        Map.put(user, :picture_url, picture_url)
+      else
+        user
+      end
+
+    IO.inspect(picture_url, label: "this is the picture_url")
 
     team =
       case get_session(conn, :current_team_id) do
@@ -303,7 +315,14 @@ defmodule TikiWeb.UserAuth do
     end)
     |> Phoenix.Component.assign_new(:current_user, fn ->
       if user_token = session["user_token"] do
-        Accounts.get_user_by_session_token(user_token)
+        user = Accounts.get_user_by_session_token(user_token)
+        picture_url = session["picture_url"]
+
+        if user && picture_url do
+          Map.put(user, :picture_url, picture_url)
+        else
+          user
+        end
       end
     end)
     |> Phoenix.Component.assign_new(:current_team, fn ->

--- a/lib/tiki_web/user_auth.ex
+++ b/lib/tiki_web/user_auth.ex
@@ -98,17 +98,6 @@ defmodule TikiWeb.UserAuth do
 
     user = user_token && Accounts.get_user_by_session_token(user_token)
 
-    picture_url = get_session(conn, :picture_url)
-
-    user =
-      if user && picture_url do
-        Map.put(user, :picture_url, picture_url)
-      else
-        user
-      end
-
-    IO.inspect(picture_url, label: "this is the picture_url")
-
     team =
       case get_session(conn, :current_team_id) do
         nil -> nil

--- a/test/support/oidcc_test_helpers.ex
+++ b/test/support/oidcc_test_helpers.ex
@@ -67,7 +67,8 @@ defmodule Tiki.OidccTestHelpers do
       "given_name" => Keyword.get(attrs, :given_name, "Test"),
       "family_name" => Keyword.get(attrs, :family_name, "User"),
       "email" => Keyword.get(attrs, :email, "#{kth_id}@kth.se"),
-      "year_tag" => Keyword.get(attrs, :year_tag, "D-23")
+      "year_tag" => Keyword.get(attrs, :year_tag, "D-23"),
+      "picture" => Keyword.get(attrs, :picture, nil)
     }
 
     # Allow overriding any field

--- a/test/tiki_web/controllers/oidcc_controller_test.exs
+++ b/test/tiki_web/controllers/oidcc_controller_test.exs
@@ -4,6 +4,8 @@ defmodule TikiWeb.OidccControllerTest do
   import Tiki.AccountsFixtures
   import Tiki.OidccTestHelpers
 
+  import Phoenix.LiveViewTest
+
   alias Tiki.Accounts
 
   # Helper to call controller action directly, bypassing Oidcc plugs
@@ -66,6 +68,32 @@ defmodule TikiWeb.OidccControllerTest do
       assert user = Accounts.get_user_by_email("noyeartag@kth.se")
       assert user.kth_id == "noyeartag"
       assert user.year_tag == nil
+    end
+
+    test "assigns user picture from claims", %{conn: conn} do
+      userinfo =
+        oidc_userinfo(
+          sub: "newuser",
+          email: "newuser@kth.se",
+          picture: "https://example.com/picture.jpg"
+        )
+
+      conn = call_oidc_callback(conn, userinfo)
+
+      assert user = Accounts.get_user_by_email("newuser@kth.se")
+      grant_permission(user, "admin")
+
+      # Test on intitial render
+      conn = get(conn, ~p"/admin/select-team")
+      html = html_response(conn, 200)
+
+      assert html =~ "newuser@kth.se"
+      assert html =~ "https://example.com/picture.jpg"
+
+      # Test on live view render/mount
+      {:ok, _lv, html} = live(conn, ~p"/admin/select-team")
+      assert html =~ "newuser@kth.se"
+      assert html =~ "https://example.com/picture.jpg"
     end
   end
 


### PR DESCRIPTION
closes #139
closes #137
^this because I needed some keys

summa summarum:
* i `lib/tiki_web/controllers/oidcc_controller.ex` översätt picture från OIDC till picture_url. Här kommer OIDC inloggningingen sättas igång som kör `Accounts.upsert_user_with_userinfo` och `UserAuth.log_in_user`

* i `lib/tiki/accounts.ex upsert_user_with_userinfo` läggs picture_url in. `Repo.get_by` kommer alltid hämta picture_url som `nil` p.g.a det ecto fältet är *virtual*

* i `lib/tiki_web/user_auth.ex`, så lägger `log_in_user` picture_url in i *sessionet*. I princip enda anledningen till varför jag lägger till picture_url i user, plus att jag inte vill mucka med vad upsert_user funktionen returnerar

* senare, i `mount_current_user` i samma fil, läggs picture_url in från *sessionet* till datan som LiveViewen ser, där den äntligen renderas.


